### PR TITLE
Avoid returning thumbnail when on the dashboard

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -40,12 +40,14 @@ export class DashboardComponent {
     { name: "creator", icon: "group", sort: true, inList: true },
     { name: "doi", icon: "label", sort: true, inList: true },
   ];
+  itemFields = {thumbnail: false};
 
   params: any = this.datasourceService.queryParams(
     this.itemsPerPage,
     this.currentPage,
     this.sortColumn,
-    this.sortDirection
+    this.sortDirection,
+    this.itemFields,
   );
   publications$: Observable<
     PublishedData[]
@@ -72,7 +74,8 @@ export class DashboardComponent {
       this.itemsPerPage,
       this.currentPage,
       this.sortColumn,
-      this.sortDirection
+      this.sortDirection,
+      this.itemFields,
     );
     this.publications$ = this.datasourceService.getPublications(this.params);
   }
@@ -85,7 +88,8 @@ export class DashboardComponent {
       this.itemsPerPage,
       this.currentPage,
       this.sortColumn,
-      this.sortDirection
+      this.sortDirection,
+      this.itemFields,
     );
     this.publications$ = this.datasourceService.getPublications(this.params);
   }

--- a/src/app/datasource.service.ts
+++ b/src/app/datasource.service.ts
@@ -36,13 +36,15 @@ export class DatasourceService {
     itemsPerPage: number,
     currentPage: number,
     sortColumn: string,
-    sortDirection: string
+    sortDirection: string,
+    itemFields: Partial<{[key in keyof PublishedData]: boolean}>
   ): string {
     return this.appConfig.directMongoAccess
       ? JSON.stringify({
           order: sortColumn + " " + sortDirection,
           skip: itemsPerPage * currentPage,
           limit: itemsPerPage,
+          fields: itemFields,
         })
       : "(" +
           "skip=" +
@@ -53,6 +55,8 @@ export class DatasourceService {
           sortColumn +
           ",sortDirection=" +
           sortDirection +
+          ",excludeFields=" +
+          Object.keys(itemFields).filter(k => !itemFields[k]).join("|") +
           ")";
   }
 }


### PR DESCRIPTION
## Description

The dashboard does not show the thumbnails to the user, and getting them results in performance issues as the data is big.

## Motivation

This PR excludes the thumbnail field setting the relative option either in the scicat be or in the oaipmh

## Changes:

* fields filter added

## Tests included/Docs Updated?

- [ ]  Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [ ] New packages used/requires npm install? 

## Extra Information/Screenshots
