### PR TITLE
Fix config value from BE config

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -19,6 +19,7 @@ export interface AppConfig {
   logoBanner: string | null;
   logoWidth?: string;
   retrieveToEmail: RetrieveDestinations | undefined;
+  lbBaseURL: string | null;
 }
 
 export class RetrieveDestinations {

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -19,7 +19,7 @@ export interface AppConfig {
   logoBanner: string | null;
   logoWidth?: string;
   retrieveToEmail: RetrieveDestinations | undefined;
-  lbBaseURL: string | null;
+  lbBaseUrl: string | null;
 }
 
 export class RetrieveDestinations {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -42,7 +42,7 @@ describe("AppComponent", () => {
     const app = fixture.componentInstance;
     fixture.detectChanges();
     expect(app.config.scicatBaseUrl).toEqual("https://scicat.esss.se");
-    expect(app.config.lbBaseURL).toEqual("https://scicat.esss.se/api");
+    expect(app.config.lbBaseUrl).toEqual("https://scicat.esss.se/api");
     expect(LoopBackConfig.getPath()).toEqual("https://scicat.esss.se/api");
   }));
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, waitForAsync } from "@angular/core/testing";
+import { fakeAsync, TestBed, waitForAsync } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AppComponent } from "./app.component";
 import { APP_CONFIG } from "./app-config.module";
@@ -6,6 +6,7 @@ import { MatToolbarModule } from "@angular/material/toolbar";
 import { HttpClientModule } from "@angular/common/http";
 import { APP_DYN_CONFIG } from "./app-config.service";
 import { MockAppConfigService } from "./shared/MockStubs";
+import { LoopBackConfig } from "./shared/sdk";
 
 describe("AppComponent", () => {
   beforeEach(waitForAsync(() => {
@@ -35,4 +36,13 @@ describe("AppComponent", () => {
     const app = fixture.componentInstance;
     expect(app.title).toEqual("ESS Public Data Repository test");
   });
+
+  it(`should test app config values'`, fakeAsync(() => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    fixture.detectChanges();
+    expect(app.config.scicatBaseUrl).toEqual("https://scicat.esss.se");
+    expect(app.config.lbBaseURL).toEqual("https://scicat.esss.se/api");
+    expect(LoopBackConfig.getPath()).toEqual("https://scicat.esss.se/api");
+  }));
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,7 +33,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    LoopBackConfig.setBaseURL(this.config.scicatBaseUrl);
+    LoopBackConfig.setBaseURL(this.config.lbBaseURL);
     console.log("API Path: ", LoopBackConfig.getPath());
     console.log("API Version: ", LoopBackConfig.getApiVersion());
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,7 +33,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    LoopBackConfig.setBaseURL(this.config.lbBaseURL);
+    LoopBackConfig.setBaseURL(this.config.lbBaseUrl);
     console.log("API Path: ", LoopBackConfig.getPath());
     console.log("API Version: ", LoopBackConfig.getApiVersion());
   }

--- a/src/app/shared/MockStubs.ts
+++ b/src/app/shared/MockStubs.ts
@@ -111,7 +111,7 @@ export class MockAppConfigService extends AppConfigService {
     accessInstructions:
       "Instructions: Login with brightness username and password",
     scicatBaseUrl: "https://scicat.esss.se",
-    lbBaseUrl: "https://scicat.esss.se",
+    lbBaseURL: "https://scicat.esss.se/api",
     retrieveToEmail: {
       option: "URLs",
       username: "lp_service",

--- a/src/app/shared/MockStubs.ts
+++ b/src/app/shared/MockStubs.ts
@@ -111,7 +111,7 @@ export class MockAppConfigService extends AppConfigService {
     accessInstructions:
       "Instructions: Login with brightness username and password",
     scicatBaseUrl: "https://scicat.esss.se",
-    lbBaseURL: "https://scicat.esss.se/api",
+    lbBaseUrl: "https://scicat.esss.se/api",
     retrieveToEmail: {
       option: "URLs",
       username: "lp_service",

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -11,7 +11,7 @@ export const environment = {
   directMongoAccess: false,
   doiBaseUrl: "https://doi.org/",
   facility: "psi",
-  lbBaseURL: "https://doi2.psi.ch:3001",
+  lbBaseUrl: "https://doi2.psi.ch:3001",
   oaiProviderRoute: "https://doi2.psi.ch/oaipmh/Publication",
   production: true,
   scicatBaseUrl: null,

--- a/src/environments/environment.dmsc.ts
+++ b/src/environments/environment.dmsc.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "ess",
-  lbBaseURL: "https://kubetest02.dm.esss.dk:32223",
+  lbBaseUrl: "https://kubetest02.dm.esss.dk:32223",
   oaiProviderRoute: null,
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",

--- a/src/environments/environment.dmscdev.ts
+++ b/src/environments/environment.dmscdev.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "ess",
-  lbBaseURL: "https://catamelservice.esss.dk:30003",
+  lbBaseUrl: "https://catamelservice.esss.dk:30003",
   oaiProviderRoute: null,
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",

--- a/src/environments/environment.dmscprod.ts
+++ b/src/environments/environment.dmscprod.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "ess",
-  lbBaseURL: "https://scicatapi.esss.dk",
+  lbBaseUrl: "https://scicatapi.esss.dk",
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat.esss.se",

--- a/src/environments/environment.docker.ts
+++ b/src/environments/environment.docker.ts
@@ -10,7 +10,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "ess",
-  lbBaseURL: "http://127.0.0.1:3000",
+  lbBaseUrl: "http://127.0.0.1:3000",
   oaiProviderRoute: null,
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",

--- a/src/environments/environment.essdev.ts
+++ b/src/environments/environment.essdev.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "ess",
-  lbBaseURL: "https://scitest.esss.lu.se",
+  lbBaseUrl: "https://scitest.esss.lu.se",
   oaiProviderRoute: null,
   production: false,
   scicatBaseUrl: "https://scitest.esss.lu.se",

--- a/src/environments/environment.essprod.ts
+++ b/src/environments/environment.essprod.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "ess",
-  lbBaseURL: "https://scicat.ess.eu",
+  lbBaseUrl: "https://scicat.ess.eu",
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat.ess.eu",

--- a/src/environments/environment.maxivdemo.ts
+++ b/src/environments/environment.maxivdemo.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "maxiv",
-  lbBaseURL: "https://scicat-demo.maxiv.lu.se",
+  lbBaseUrl: "https://scicat-demo.maxiv.lu.se",
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat-demo.maxiv.lu.se",

--- a/src/environments/environment.maxivdev.ts
+++ b/src/environments/environment.maxivdev.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "maxiv",
-  lbBaseURL: "https://scicat-test.maxiv.lu.se",
+  lbBaseUrl: "https://scicat-test.maxiv.lu.se",
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat-test.maxiv.lu.se",

--- a/src/environments/environment.maxivprod.ts
+++ b/src/environments/environment.maxivprod.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "maxiv",
-  lbBaseURL: "https://scicat.maxiv.lu.se",
+  lbBaseUrl: "https://scicat.maxiv.lu.se",
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat.maxiv.lu.se",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,7 +6,7 @@ export const environment = {
   directMongoAccess: false,
   doiBaseUrl: "https://doi.org/",
   facility: "psi",
-  lbBaseURL: "https://doi.psi.ch:3001",
+  lbBaseUrl: "https://doi.psi.ch:3001",
   oaiProviderRoute: "https://doi.psi.ch/oaipmh/Publication",
   production: true,
   scicatBaseUrl: null,

--- a/src/environments/environment.qa.ts
+++ b/src/environments/environment.qa.ts
@@ -4,7 +4,7 @@ export const environment = {
   directMongoAccess: false,
   doiBaseUrl: "https://doi.org/",
   facility: "PSI",
-  lbBaseURL: "https://dacat-qa.psi.ch",
+  lbBaseUrl: "https://dacat-qa.psi.ch",
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: null,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,7 +9,7 @@ export const environment = {
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
   facility: "ess",
-  lbBaseURL: "http://localhost:3000",
+  lbBaseUrl: "http://localhost:3000",
   oaiProviderRoute: "http://127.0.0.1:3001",
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",


### PR DESCRIPTION
## Description

Fix LoopBackConfig to take the correct field from the config

## Motivation

The LoopBackConfig instantiation takes the wrong field from the config.

scicatBaseUrl is the FE URL. This is used, e.g., when needing to be redirected to the scicat FE on dataset click from within a publication detail page

lbBaseURL is the BE URL used for data querying 

## Fixes:

* scicatBaseUrl to lbBaseURL field from config 

## Changes:

* changes made

## Tests included/Docs Updated?

- [x]  Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [ ] New packages used/requires npm install? 

## Extra Information/Screenshots
