### PR TITLE
feat: url-encode DOI slashes as %2F to ensure proper interpretation

### DIFF
--- a/src/app/publisheddata-details/publisheddata-details.component.html
+++ b/src/app/publisheddata-details/publisheddata-details.component.html
@@ -41,8 +41,8 @@
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="{{ doiBaseUrl + doi }}"
-                  >{{ doiBaseUrl + doi }}</a
+                  href="{{ doiBaseUrl + encodeUriComponent(doi) }}"
+                  >{{ doiBaseUrl + encodeUriComponent(doi) }}</a
                 >
               </td>
             </tr>

--- a/src/app/publisheddata-details/publisheddata-details.component.ts
+++ b/src/app/publisheddata-details/publisheddata-details.component.ts
@@ -92,6 +92,10 @@ export class PublisheddataDetailsComponent implements OnInit {
     };
   }
 
+  encodeUriComponent(value: string): string {
+    return encodeURIComponent(value);
+  }
+
   ngOnInit(): void {
     const params = this.route.snapshot.params;
     const id: string =


### PR DESCRIPTION
## Description

This PR ensures that any slashes (/) in DOIs are URL-encoded as %2F. This guarantees that DOIs are treated as unique, complete strings when passed to the server or external services. Without this encoding, the slash may is misinterpreted as a path separator.

Fixes issue #390

## Motivation

When having a DOI reachable, for instance, at DataCite, the URL is interpreted wrongly as it uses the "slash" from the DOI instead of replacing it with %2F.

## Fixes:

Passed the DOI to the encodeUriComponent wrapper of the encodeURIComponent built-in function.
Defined the encodeUriComponent wrapper.

## Changes:

Replaced doi by encodeUriComponent(doi) in src/app/publisheddata-details/publisheddata-details.component.html
Defined the encodeUriComponent() wrapper in src/app/publisheddata-details/publisheddata-details.component.ts

## Tests included/Docs Updated?

- [ ]  Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [ ] New packages used/requires npm install? 

## Extra Information/Screenshots
