### PR TITLE
Add a configurable status message banner

### DIFF
--- a/src/app/app-config.module.ts
+++ b/src/app/app-config.module.ts
@@ -13,12 +13,14 @@ export class AppConfig {
   accessInstructions = "";
   scicatBaseUrl = "";
   showLogoBanner = true;
-  retrieveToEmail: {
-    title: string; 
-    option: string; 
-    username: string;
-    confirmMessage?: string;
-  } | undefined = undefined;
+  retrieveToEmail:
+    | {
+        title: string;
+        option: string;
+        username: string;
+        confirmMessage?: string;
+      }
+    | undefined = undefined;
   statusMessage = "";
   statusCode: "INFO" | "WARN" | "NONE" = "NONE";
 }
@@ -36,7 +38,8 @@ export const APP_DI_CONFIG: AppConfig = {
   retrieveToEmail: environment["retrieveToEmail"] ?? undefined,
   statusMessage: environment["statusMessage"] || "",
   statusCode: (["INFO", "WARN", "NONE"].includes(environment["statusCode"])
-    ? environment["statusCode"] : "NONE") as "INFO" | "WARN" | "NONE",
+    ? environment["statusCode"]
+    : "NONE") as "INFO" | "WARN" | "NONE",
 };
 
 @NgModule({

--- a/src/app/app-config.module.ts
+++ b/src/app/app-config.module.ts
@@ -5,37 +5,12 @@ export const APP_CONFIG = new InjectionToken<AppConfig>("app.config");
 
 export class AppConfig {
   production = true;
-  facility = "";
-  oaiProviderRoute = "";
-  doiBaseUrl = "";
-  directMongoAccess = true;
-  accessDataHref = "";
-  accessInstructions = "";
-  scicatBaseUrl = "";
-  showLogoBanner = true;
-  retrieveToEmail:
-    | {
-        title: string;
-        option: string;
-        username: string;
-        confirmMessage?: string;
-      }
-    | undefined = undefined;
   statusMessage = "";
   statusCode: "INFO" | "WARN" | "NONE" = "NONE";
 }
 
 export const APP_DI_CONFIG: AppConfig = {
   production: environment.production,
-  facility: environment.facility ?? "",
-  oaiProviderRoute: environment.oaiProviderRoute ?? "",
-  doiBaseUrl: environment.doiBaseUrl ?? "",
-  directMongoAccess: environment.directMongoAccess ?? false,
-  accessDataHref: environment.accessDataHref ?? "",
-  accessInstructions: environment.accessInstructions ?? "",
-  scicatBaseUrl: environment.scicatBaseUrl ?? "",
-  showLogoBanner: environment.showLogoBanner ?? false,
-  retrieveToEmail: environment["retrieveToEmail"] ?? undefined,
   statusMessage: environment["statusMessage"] || "",
   statusCode: (["INFO", "WARN", "NONE"].includes(environment["statusCode"])
     ? environment["statusCode"]

--- a/src/app/app-config.module.ts
+++ b/src/app/app-config.module.ts
@@ -5,10 +5,38 @@ export const APP_CONFIG = new InjectionToken<AppConfig>("app.config");
 
 export class AppConfig {
   production = true;
+  facility = "";
+  oaiProviderRoute = "";
+  doiBaseUrl = "";
+  directMongoAccess = true;
+  accessDataHref = "";
+  accessInstructions = "";
+  scicatBaseUrl = "";
+  showLogoBanner = true;
+  retrieveToEmail: {
+    title: string; 
+    option: string; 
+    username: string;
+    confirmMessage?: string;
+  } | undefined = undefined;
+  statusMessage = "";
+  statusCode: "INFO" | "WARN" | "NONE" = "NONE";
 }
 
 export const APP_DI_CONFIG: AppConfig = {
   production: environment.production,
+  facility: environment.facility ?? "",
+  oaiProviderRoute: environment.oaiProviderRoute ?? "",
+  doiBaseUrl: environment.doiBaseUrl ?? "",
+  directMongoAccess: environment.directMongoAccess ?? false,
+  accessDataHref: environment.accessDataHref ?? "",
+  accessInstructions: environment.accessInstructions ?? "",
+  scicatBaseUrl: environment.scicatBaseUrl ?? "",
+  showLogoBanner: environment.showLogoBanner ?? false,
+  retrieveToEmail: environment["retrieveToEmail"] ?? undefined,
+  statusMessage: environment["statusMessage"] || "",
+  statusCode: (["INFO", "WARN", "NONE"].includes(environment["statusCode"])
+    ? environment["statusCode"] : "NONE") as "INFO" | "WARN" | "NONE",
 };
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,8 @@
+<app-status-banner
+  *ngIf="showStatusBanner"
+  (dismiss)="showStatusBanner = false"
+></app-status-banner>
+
 <mat-toolbar class="mat-elevation-z1" color="primary">
   <mat-toolbar-row>
     <span class="spacer">{{ title }}</span>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -7,11 +7,17 @@ import { HttpClientModule } from "@angular/common/http";
 import { APP_DYN_CONFIG } from "./app-config.service";
 import { MockAppConfigService } from "./shared/MockStubs";
 import { LoopBackConfig } from "./shared/sdk";
+import { StatusMessageModule } from "./shared/modules/status-message/status-message.module";
 
 describe("AppComponent", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatToolbarModule, RouterTestingModule, HttpClientModule],
+      imports: [
+        MatToolbarModule,
+        RouterTestingModule,
+        HttpClientModule,
+        StatusMessageModule,
+      ],
       declarations: [AppComponent],
       providers: [
         {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,6 +14,7 @@ import {
 })
 export class AppComponent implements OnInit {
   title = "Public Data Repository";
+  showStatusBanner = false;
 
   config: Config;
 
@@ -36,5 +37,6 @@ export class AppComponent implements OnInit {
     LoopBackConfig.setBaseURL(this.config.lbBaseUrl);
     console.log("API Path: ", LoopBackConfig.getPath());
     console.log("API Version: ", LoopBackConfig.getApiVersion());
+    this.showStatusBanner = this.appConfig.statusCode !== "NONE";
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { SDKBrowserModule } from "./shared/sdk";
 import { APP_DYN_CONFIG, AppConfigService } from "./app-config.service";
 import { HttpClientModule } from "@angular/common/http";
 import { AppThemeService } from "./app-theme.service";
+import { StatusMessageModule } from "./shared/modules/status-message/status-message.module";
 
 const appConfigInitializerFn = (appConfig: AppConfigService) => {
   return () => appConfig.loadAppConfig();
@@ -27,6 +28,7 @@ const appThemeInitializerFn = (appTheme: AppThemeService) => {
     BrowserAnimationsModule,
     BrowserModule,
     MatToolbarModule,
+    StatusMessageModule,
     SDKBrowserModule.forRoot(),
     HttpClientModule,
   ],

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.html
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.html
@@ -1,0 +1,7 @@
+<mat-toolbar [color]="bannerColor" style="height: 32px">
+  <span [innerHTML]="appConfig.statusMessage"></span>
+  <span class="spacer"></span>
+  <button mat-icon-button aria-label="Dismiss" (click)="onDismiss()">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-toolbar>

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.html
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.html
@@ -1,5 +1,5 @@
-<mat-toolbar [color]="bannerColor" style="height: 32px">
-  <span [innerHTML]="appConfig.statusMessage"></span>
+<mat-toolbar [color]="bannerColor" class="toolbar">
+  <span [innerHTML]="appConfig.statusMessage" class="status-message"></span>
   <span class="spacer"></span>
   <button mat-icon-button aria-label="Dismiss" (click)="onDismiss()">
     <mat-icon>close</mat-icon>

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.scss
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.scss
@@ -1,0 +1,3 @@
+.spacer {
+  flex: 1 1 auto;
+}

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.scss
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.scss
@@ -1,3 +1,17 @@
 .spacer {
   flex: 1 1 auto;
 }
+
+.toolbar {
+  height: 32px;
+}
+
+@media (max-width: 800px) {
+  .toolbar {
+    height: 64px;
+  }
+  .status-message {
+    text-wrap: wrap;
+    font-size: 16px;
+  }
+}

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StatusBannerComponent } from './status-banner.component';
+
+describe('StatusBannerComponent', () => {
+  let component: StatusBannerComponent;
+  let fixture: ComponentFixture<StatusBannerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ StatusBannerComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StatusBannerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { StatusBannerComponent } from './status-banner.component';
+import { APP_CONFIG } from 'src/app/app-config.module';
 
 describe('StatusBannerComponent', () => {
   let component: StatusBannerComponent;
@@ -8,7 +9,16 @@ describe('StatusBannerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ StatusBannerComponent ]
+      declarations: [ StatusBannerComponent ],
+      providers: [
+        {
+          provide: APP_CONFIG,
+          useValue: {
+            facility: "ess",
+            production: false,
+          },
+        },
+      ],
     })
     .compileComponents();
   });

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
@@ -2,6 +2,10 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { StatusBannerComponent } from "./status-banner.component";
 import { APP_CONFIG } from "src/app/app-config.module";
+import { CommonModule } from "@angular/common";
+import { MatButtonModule } from "@angular/material/button";
+import { MatIconModule } from "@angular/material/icon";
+import { MatToolbarModule } from "@angular/material/toolbar";
 
 describe("StatusBannerComponent", () => {
   let component: StatusBannerComponent;
@@ -10,6 +14,7 @@ describe("StatusBannerComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [StatusBannerComponent],
+      imports: [CommonModule, MatToolbarModule, MatButtonModule, MatIconModule],
       providers: [
         {
           provide: APP_CONFIG,

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
@@ -9,7 +9,7 @@ describe("StatusBannerComponent", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ StatusBannerComponent ],
+      declarations: [StatusBannerComponent],
       providers: [
         {
           provide: APP_CONFIG,
@@ -19,8 +19,7 @@ describe("StatusBannerComponent", () => {
           },
         },
       ],
-    })
-    .compileComponents();
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.spec.ts
@@ -1,9 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 
-import { StatusBannerComponent } from './status-banner.component';
-import { APP_CONFIG } from 'src/app/app-config.module';
+import { StatusBannerComponent } from "./status-banner.component";
+import { APP_CONFIG } from "src/app/app-config.module";
 
-describe('StatusBannerComponent', () => {
+describe("StatusBannerComponent", () => {
   let component: StatusBannerComponent;
   let fixture: ComponentFixture<StatusBannerComponent>;
 
@@ -29,7 +29,7 @@ describe('StatusBannerComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.ts
@@ -1,10 +1,10 @@
-import { Component, Inject, Output, EventEmitter } from '@angular/core';
-import { APP_CONFIG, AppConfig } from 'src/app/app-config.module';
+import { Component, Inject, Output, EventEmitter } from "@angular/core";
+import { APP_CONFIG, AppConfig } from "src/app/app-config.module";
 
 @Component({
-  selector: 'app-status-banner',
-  templateUrl: './status-banner.component.html',
-  styleUrls: ['./status-banner.component.scss']
+  selector: "app-status-banner",
+  templateUrl: "./status-banner.component.html",
+  styleUrls: ["./status-banner.component.scss"]
 })
 export class StatusBannerComponent {
   @Output() dismiss = new EventEmitter<void>();
@@ -17,9 +17,9 @@ export class StatusBannerComponent {
 
   get bannerColor() {
     switch (this.appConfig.statusCode) {
-      case 'INFO': return 'accent';
-      case 'WARN': return 'warn';
-      default: return '';
+      case "INFO": return "accent";
+      case "WARN": return "warn";
+      default: return "";
     }
   }
 }

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.ts
@@ -4,12 +4,12 @@ import { APP_CONFIG, AppConfig } from "src/app/app-config.module";
 @Component({
   selector: "app-status-banner",
   templateUrl: "./status-banner.component.html",
-  styleUrls: ["./status-banner.component.scss"]
+  styleUrls: ["./status-banner.component.scss"],
 })
 export class StatusBannerComponent {
   @Output() dismiss = new EventEmitter<void>();
 
-  constructor(@Inject(APP_CONFIG) public appConfig: AppConfig) { }
+  constructor(@Inject(APP_CONFIG) public appConfig: AppConfig) {}
 
   onDismiss() {
     this.dismiss.emit();
@@ -17,9 +17,12 @@ export class StatusBannerComponent {
 
   get bannerColor() {
     switch (this.appConfig.statusCode) {
-      case "INFO": return "accent";
-      case "WARN": return "warn";
-      default: return "";
+      case "INFO":
+        return "accent";
+      case "WARN":
+        return "warn";
+      default:
+        return "";
     }
   }
 }

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.ts
@@ -1,0 +1,25 @@
+import { Component, Inject, Output, EventEmitter } from '@angular/core';
+import { APP_CONFIG, AppConfig } from 'src/app/app-config.module';
+
+@Component({
+  selector: 'app-status-banner',
+  templateUrl: './status-banner.component.html',
+  styleUrls: ['./status-banner.component.scss']
+})
+export class StatusBannerComponent {
+  @Output() dismiss = new EventEmitter<void>();
+
+  constructor(@Inject(APP_CONFIG) public appConfig: AppConfig) { }
+
+  onDismiss() {
+    this.dismiss.emit();
+  }
+
+  get bannerColor() {
+    switch (this.appConfig.statusCode) {
+      case 'INFO': return 'accent';
+      case 'WARN': return 'warn';
+      default: return '';
+    }
+  }
+}

--- a/src/app/shared/modules/status-message/status-message.module.ts
+++ b/src/app/shared/modules/status-message/status-message.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { StatusBannerComponent } from './status-banner/status-banner.component';
+import { MatIconModule } from '@angular/material/icon';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+
+
+
+@NgModule({
+  declarations: [
+    StatusBannerComponent
+  ],
+  imports: [
+    CommonModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule
+  ],
+  exports: [StatusBannerComponent],
+})
+export class StatusMessageModule { }

--- a/src/app/shared/modules/status-message/status-message.module.ts
+++ b/src/app/shared/modules/status-message/status-message.module.ts
@@ -1,9 +1,9 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { StatusBannerComponent } from './status-banner/status-banner.component';
-import { MatIconModule } from '@angular/material/icon';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatButtonModule } from '@angular/material/button';
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { StatusBannerComponent } from "./status-banner/status-banner.component";
+import { MatIconModule } from "@angular/material/icon";
+import { MatToolbarModule } from "@angular/material/toolbar";
+import { MatButtonModule } from "@angular/material/button";
 
 
 

--- a/src/app/shared/modules/status-message/status-message.module.ts
+++ b/src/app/shared/modules/status-message/status-message.module.ts
@@ -5,18 +5,9 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatButtonModule } from "@angular/material/button";
 
-
-
 @NgModule({
-  declarations: [
-    StatusBannerComponent
-  ],
-  imports: [
-    CommonModule,
-    MatToolbarModule,
-    MatButtonModule,
-    MatIconModule
-  ],
+  declarations: [StatusBannerComponent],
+  imports: [CommonModule, MatToolbarModule, MatButtonModule, MatIconModule],
   exports: [StatusBannerComponent],
 })
-export class StatusMessageModule { }
+export class StatusMessageModule {}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,8 +14,6 @@ export const environment = {
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",
   showLogoBanner: true,
-  statusMessage: "hello",
-  statusCode: "INFO",
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,6 +14,8 @@ export const environment = {
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",
   showLogoBanner: true,
+  statusMessage: "hello",
+  statusCode: "INFO",
 };
 
 /*


### PR DESCRIPTION
## Description

This PR adds a status message banner that can be shown based on values in `environment.ts`, `statusMessage` and `statusCode` which can be one of `INFO | WARN | NONE`. If statusCode/statusMessage is ommited, no banner is shown hence preserving original behavior.

## Motivation

During outages, it is useful to show a status message banner on top of the landing page. E.g. `statusCode = WARN`:
![warn_banner](https://github.com/user-attachments/assets/afa7a664-e3f7-48b9-af5f-74a7c2ba95ff)

Or to update the users that the issue has been fixed (i.e. `statusCode = INFO`):
![banner_info](https://github.com/user-attachments/assets/b12badd3-a486-4885-b646-05e609cc5498)


## Fixes:

* none

## Changes:

* added a status-banner component, that's in its own NgModule
* Import it in app-component, and trigger visibility based on `statusCode` env variable.

## Tests included/Docs Updated?

- [x]  Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [x] New packages used/requires npm install? - no new packages added

## Extra Information/Screenshots
