### PR TITLE
Improve color scheme and responsiveness of status message banner

### DIFF
--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.html
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar [color]="bannerColor" class="toolbar">
+<mat-toolbar [color]="bannerColor" [class]='["toolbar", "toolbar-" + appConfig.statusCode]'>
   <span [innerHTML]="appConfig.statusMessage" class="status-message"></span>
   <span class="spacer"></span>
   <button mat-icon-button aria-label="Dismiss" (click)="onDismiss()">

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.scss
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.scss
@@ -3,15 +3,32 @@
 }
 
 .toolbar {
-  height: 32px;
+  min-height: 32px;
+  height: fit-content;
 }
 
+.status-message {
+  text-wrap: wrap;
+}
+
+.toolbar-WARN {
+  background-color: #FEEFB3;
+  color: #9F6000;
+}
+
+.toolbar-INFO {
+  color: #4F8A10;
+  background-color: #DFF2BF;
+}
+
+
 @media (max-width: 800px) {
-  .toolbar {
-    height: 64px;
-  }
   .status-message {
-    text-wrap: wrap;
     font-size: 16px;
   }
+}
+
+:host ::ng-deep a {
+  text-decoration: underline;
+  color: inherit;
 }


### PR DESCRIPTION
## Description

https://github.com/SciCatProject/LandingPageServer/pull/394 introduced a configurable status message banner, however the color scheme and appearance of hyperlinks was unpleasant. This PR updates this with nicer [colors](https://gist.github.com/istudyatuni/a5c7e66bbdda4da2ad757de4d97ddd87). 

## Motivation
statusCode == WARN:
![banner-warn](https://github.com/user-attachments/assets/79551c7e-0149-4287-8890-3373f86c6bb0)

statusCode == INFO, and smaller screen:
![Screenshot from 2025-07-02 13-41-31](https://github.com/user-attachments/assets/ccf513ad-fcdd-4a68-a658-9914452f7983)


## Fixes:

* Fixed status banner appearance on smaller screens

## Changes:

* Updated status message component's CSS
* Add CSS class dynamically based on statusCode

## Tests included/Docs Updated?

- [x]  Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [ ] New packages used/requires npm install? 

## Extra Information/Screenshots
