### PR TITLE
(feat) help message footer with configurable contactEmail

### DIFF
--- a/src/app/app-config.module.ts
+++ b/src/app/app-config.module.ts
@@ -7,6 +7,7 @@ export class AppConfig {
   production = true;
   statusMessage = "";
   statusCode: "INFO" | "WARN" | "NONE" = "NONE";
+  contactEmail = "";
 }
 
 export const APP_DI_CONFIG: AppConfig = {
@@ -15,6 +16,7 @@ export const APP_DI_CONFIG: AppConfig = {
   statusCode: (["INFO", "WARN", "NONE"].includes(environment["statusCode"])
     ? environment["statusCode"]
     : "NONE") as "INFO" | "WARN" | "NONE",
+  contactEmail: environment["contactEmail"] || "",
 };
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -12,6 +12,13 @@
 
 <router-outlet></router-outlet>
 
-<mat-toolbar class="footer" *ngIf="config.showLogoBanner">
-  <img src="../assets/{{ config.logoBanner }}" width="{{ config.logoWidth }}" alt="logo_banner" />
-</mat-toolbar>
+<footer class="footer">
+  <mat-toolbar class="logo-banner" *ngIf="config.showLogoBanner">
+    <img src="../assets/{{ config.logoBanner }}" width="{{ config.logoWidth }}" alt="logo_banner" />
+  </mat-toolbar>
+
+  <address *ngIf="appConfig.contactEmail">
+    If you have any questions or need help, please contact <a href="mailto:{{ appConfig.contactEmail }}">{{
+      appConfig.contactEmail }}</a>.
+  </address>
+</footer>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,4 +1,9 @@
 /* AppComponent's private CSS styles */
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
 
 .header {
   position: sticky;
@@ -7,9 +12,19 @@
 }
 
 .footer {
+  margin-top: auto;
+}
+
+.logo-banner {
   height: 77px;
   justify-content: center;
   background-color: var(--theme-primary-default-contrast);
+}
+
+address {
+  font-size: 16px;
+  padding: 0.5em;
+  background-color: whitesmoke;
 }
 
 .spacer {

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.html
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar [color]="bannerColor" [class]='["toolbar", "toolbar-" + appConfig.statusCode]'>
+<mat-toolbar [class]='["toolbar", "toolbar-" + appConfig.statusCode]'>
   <span [innerHTML]="appConfig.statusMessage" class="status-message"></span>
   <span class="spacer"></span>
   <button mat-icon-button aria-label="Dismiss" (click)="onDismiss()">

--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.ts
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.ts
@@ -14,15 +14,4 @@ export class StatusBannerComponent {
   onDismiss() {
     this.dismiss.emit();
   }
-
-  get bannerColor() {
-    switch (this.appConfig.statusCode) {
-      case "INFO":
-        return "accent";
-      case "WARN":
-        return "warn";
-      default:
-        return "";
-    }
-  }
 }


### PR DESCRIPTION
## Description

Added a footer with configurable `contactEmail`  appConfig key read from environment.ts. If the `contactEmail` is not set or empty, no footer is shown. 

## Motivation

Users currently have no information on whom to contact in case of issues. This fixes it by adding a help message footer:
![Screenshot from 2025-07-07 14-17-16](https://github.com/user-attachments/assets/1af00f09-f63c-4e25-b77d-78cdfa6e90ab)


## Fixes:

* Fixed logo banner positioning (is pushed to the bottom even if there isn't a lot of content), following the best practices for footers ([blog](https://matthewjamestaylor.com/bottom-footer))
 
## Changes:

* The footer with contact email added
* The fix mentioned above
* Removed the now unused get bannerColor method from status message banner

## Tests included/Docs Updated?

- [ ]  Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [ ] New packages used/requires npm install? 

## Extra Information/Screenshots
