### PR TITLE
Change status-message to non-flex container to avoid issues with links

### DIFF
--- a/src/app/shared/modules/status-message/status-banner/status-banner.component.scss
+++ b/src/app/shared/modules/status-message/status-banner/status-banner.component.scss
@@ -8,10 +8,9 @@
 }
 
 .status-message {
+  text-align: center;
   text-wrap: wrap;
-  display: flex;
   width: 100%;
-  justify-content: center;
 }
 
 .toolbar-WARN {


### PR DESCRIPTION
## Description

Without this change, if the `statusMessage` contains a link (an `<a>` element), the spaces around it are not rendered as it was inside a flex container. Fixed this by making it a non-flex container and centering text with `text-align: center` instead

## Tests included/Docs Updated?

- [ ]  Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [ ] New packages used/requires npm install? 

## Extra Information/Screenshots
For `statusMessage: "Dataset retrieval is currently down due to technical issues with Tape Library at CSCS. Visit <a href='https://scistatus.psi.ch/'>scistatus.psi.ch</a> for more information.",`

Before:
<img width="1322" height="108" alt="Screenshot from 2025-07-31 13-01-50" src="https://github.com/user-attachments/assets/033c138b-6202-408e-928c-cda0b2b3a94d" />


After:
<img width="1176" height="103" alt="Screenshot from 2025-07-31 13-01-18" src="https://github.com/user-attachments/assets/28d71c21-9a9c-4b47-a4fe-76d3eb8937a7" />

