### PR TITLE
Remove unsupported tag property from build-release gh workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,8 +2,6 @@ name: Build release
 
 on:
   release:
-    tags:
-      - 'v*'
     types:
       - created
 


### PR DESCRIPTION
## Description

As per the [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release), the tags property is not present on the `release` event. I suspect this is blocking the workflow from running on a new release (e.g. [v3.4](https://github.com/SciCatProject/LandingPageServer/releases/tag/v3.4) - however the build-release workflow [wasn't run](https://github.com/SciCatProject/LandingPageServer/actions/workflows/build-release.yml))

## Tests included/Docs Updated?

- [ ]  Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [ ] New packages used/requires npm install? 

## Extra Information/Screenshots
