### PR TITLE
feat(toolbar): navigate to home when clicking title banner (#400)

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,9 @@
 
 <mat-toolbar class="mat-elevation-z1" color="primary">
   <mat-toolbar-row>
-    <span class="spacer">{{ title }}</span>
+    <span class="spacer">
+      <span class="title-click" (click)="navigateHome()">{{ title }}</span>
+    </span>
     <span id="doiValue"></span>
   </mat-toolbar-row>
 </mat-toolbar>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -7,7 +7,7 @@
 
 .header {
   position: sticky;
-  position: -webkit-sticky;
+  top: 0;
   z-index: 1000;
 }
 
@@ -30,4 +30,10 @@ address {
 .spacer {
   flex: 1 1 auto;
   text-align: left;
+}
+
+.title-click {
+  cursor: pointer;
+  user-select: none;
+  display: inline-block;
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -7,6 +7,8 @@ import { APP_DYN_CONFIG } from "./app-config.service";
 import { MockAppConfigService } from "./shared/MockStubs";
 import { LoopBackConfig } from "./shared/sdk";
 import { StatusMessageModule } from "./shared/modules/status-message/status-message.module";
+import { Router } from "@angular/router";
+import { By } from "@angular/platform-browser";
 
 describe("AppComponent", () => {
   beforeEach(waitForAsync(() => {
@@ -42,4 +44,18 @@ describe("AppComponent", () => {
     expect(app.config.lbBaseUrl).toEqual("https://scicat.esss.se/api");
     expect(LoopBackConfig.getPath()).toEqual("https://scicat.esss.se/api");
   }));
+
+  it(`should navigate to home when clicking the title'`, () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    const router = TestBed.inject(Router);
+    const navigateSpy = spyOn(router, "navigate");
+
+    const titleEl = fixture.debugElement.query(By.css(".title-click"));
+    expect(titleEl).toBeTruthy();
+
+    titleEl.nativeElement.click();
+    expect(navigateSpy).toHaveBeenCalledWith(["/"]);
+  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component, Inject, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
 import { LoopBackConfig } from "./shared/sdk";
 import { Title } from "@angular/platform-browser";
 import {
@@ -6,6 +7,7 @@ import {
   AppConfigService,
   AppConfig as Config,
 } from "./app-config.service";
+
 @Component({
   selector: "app-root",
   templateUrl: "./app.component.html",
@@ -14,12 +16,12 @@ import {
 export class AppComponent implements OnInit {
   title = "Public Data Repository";
   showStatusBanner = false;
-
   config: Config;
 
   constructor(
     private titleService: Title,
     @Inject(APP_DYN_CONFIG) private appConfigService: AppConfigService,
+    private router: Router,
   ) {
     this.config = this.appConfigService.getConfig();
     const facility = this.config.facility ?? "";
@@ -36,5 +38,9 @@ export class AppComponent implements OnInit {
     console.log("API Path: ", LoopBackConfig.getPath());
     console.log("API Version: ", LoopBackConfig.getApiVersion());
     this.showStatusBanner = this.config.statusCode !== "NONE";
+  }
+
+  navigateHome() {
+    this.router.navigate(["/"]);
   }
 }


### PR DESCRIPTION
## Description

Implements navigation to the home page when clicking the title banner in the toolbar.  
Only the title text is clickable, following common UX conventions.

## Motivation

Currently, if a user is on a publication detail page, there is no direct way to return to the home page.  
This change improves navigation and aligns with standard web application behavior.

## Fixes:

* #400 – Clicking the title banner now navigates to the home page.

## Changes:

* Added `(click)` event to the title span in the toolbar.
* Injected Angular `Router` in `AppComponent` to perform navigation.
* Updated CSS so that only the title text is clickable, not the entire toolbar.

## Tests included/Docs Updated?

- [x]  Included for each change/fix? *(n/a for this UI-only change)*
- [x]  Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated? *(no docs affected)*
- [ ]  New packages used/requires npm install? *(none)*

## Extra Information/Screenshots

**Before:** Clicking the title had no effect.  
**After:** Clicking the title navigates to `/` (home page).
