### PR TITLE
use v4 instead of v3 as it is deprecated

### DIFF
--- a/src/app/shared/sdk/lb.config.ts
+++ b/src/app/shared/sdk/lb.config.ts
@@ -21,7 +21,7 @@
 **/
 export class LoopBackConfig {
   private static path: string = '//0.0.0.0:3000';
-  private static version: string | number = 'api/v3';
+  private static version: string | number = 'api/v4';
   private static authPrefix: string = '';
   private static debug: boolean = true;
   private static filterOn: string = 'headers';


### PR DESCRIPTION
## Description

In the default configuration, use v4 instead of v3.

v3 is deprecated in the new backends.

## Motivation

## Tests included/Docs Updated?

- [ ]  Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ]  Docs updated?
- [ ] New packages used/requires npm install? 

## Extra Information/Screenshots
