### PR TITLE
BREAKING: use new backend syntax for limits

### DIFF
--- a/src/app/datasource.service.ts
+++ b/src/app/datasource.service.ts
@@ -54,9 +54,11 @@ export class DatasourceService {
   ): string {
     return this.directMongoAccess
       ? JSON.stringify({
-          order: sortColumn + " " + sortDirection,
-          skip: itemsPerPage * currentPage,
-          limit: itemsPerPage,
+          limits: {
+            skip: itemsPerPage * currentPage,
+            limit: itemsPerPage,
+            order: sortColumn + ":" + sortDirection,
+          },
           fields: itemFields,
         })
       : "(" +


### PR DESCRIPTION
## Description

New backend uses a slightly different syntax for filters. This fixes it, while breaking compatibility with the old backend