### PR TITLE
display decoded DOI in url

### DIFF
--- a/src/app/publisheddata-details/publisheddata-details.component.html
+++ b/src/app/publisheddata-details/publisheddata-details.component.html
@@ -42,7 +42,7 @@
                   target="_blank"
                   rel="noopener noreferrer"
                   href="{{ doiBaseUrl + encodeUriComponent(doi) }}"
-                  >{{ doiBaseUrl + encodeUriComponent(doi) }}</a
+                  >{{ doiBaseUrl + doi }}</a
                 >
               </td>
             </tr>


### PR DESCRIPTION
## Description

Changing just the display url to be copiable

## Motivation

Looks better and enables direct copying of the url.

## Fixes:

* none

## Changes:

* rm encoding function around doi in url
