### PR TITLE
feat: customizable footer message

### DIFF
--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -38,7 +38,6 @@ describe("AppConfigService", () => {
       accessDataHref: "test-access",
       accessInstructions: "test-instructions",
       scicatBaseUrl: "test-scicat",
-      showLogoBanner: true,
       logoBanner: "test-logo",
       lbBaseUrl: "test-lb",
       statusMessage: "test-status",
@@ -65,7 +64,6 @@ describe("AppConfigService", () => {
       accessDataHref: "test-access",
       accessInstructions: "test-instructions",
       scicatBaseUrl: "test-scicat",
-      showLogoBanner: true,
       logoBanner: "test-logo",
       lbBaseUrl: "test-lb",
     };

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -17,7 +17,6 @@ export interface AppConfig {
   accessDataHref: string;
   accessInstructions: string;
   scicatBaseUrl: string;
-  showLogoBanner: boolean;
   logoBanner: string | null;
   logoWidth?: string;
   retrieveToEmail: RetrieveDestinations | undefined;
@@ -25,6 +24,7 @@ export interface AppConfig {
   statusMessage: string;
   statusCode: "INFO" | "WARN" | "NONE";
   contactEmail: string;
+  footerMessage?: FooterMessage;
 }
 
 export class RetrieveDestinations {
@@ -32,6 +32,16 @@ export class RetrieveDestinations {
   option: string;
   username: string;
   confirmMessage: string | undefined;
+}
+
+interface FooterMessage {
+  text: string;
+  links: FooterMessageLink[];
+}
+
+interface FooterMessageLink {
+  label: string;
+  url: string;
 }
 
 @Injectable({ providedIn: "root" })

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,12 +15,15 @@
 <router-outlet></router-outlet>
 
 <footer class="footer">
-  <mat-toolbar class="logo-banner" *ngIf="config.showLogoBanner">
-    <img src="../assets/{{ config.logoBanner }}" width="{{ config.logoWidth }}" alt="logo_banner" />
-  </mat-toolbar>
-
   <address *ngIf="config.contactEmail">
     If you have any questions or need help, please contact <a href="mailto:{{ config.contactEmail }}">{{
       config.contactEmail }}</a>.
   </address>
+
+  <div class="footer-links" *ngIf="config.footerMessage as footerMessage">
+    <span *ngIf="footerMessage.text" [innerHTML]="footerMessage.text"></span>
+    <ng-container *ngFor="let link of footerMessage.links; let last = last">
+      <a [href]="link.url">{{ link.label }}</a><span *ngIf="!last"> | </span>
+    </ng-container>
+  </div>
 </footer>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -21,7 +21,7 @@
   background-color: var(--theme-primary-default-contrast);
 }
 
-address {
+.footer-links, address {
   font-size: 16px;
   padding: 0.5em;
   background-color: whitesmoke;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -30,19 +30,19 @@ describe("AppComponent", () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'ESS Public Data Repository test'`, () => {
+  it("should set the title from the configured facility", () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual("ESS Public Data Repository test");
+    expect(app.title).toEqual("THE_FACILITY Public Data Repository test");
   });
 
   it(`should test app config values'`, fakeAsync(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     fixture.detectChanges();
-    expect(app.config.scicatBaseUrl).toEqual("https://scicat.esss.se");
-    expect(app.config.lbBaseUrl).toEqual("https://scicat.esss.se/api");
-    expect(LoopBackConfig.getPath()).toEqual("https://scicat.esss.se/api");
+    expect(app.config.scicatBaseUrl).toEqual("https://scicat.eu/scicat");
+    expect(app.config.lbBaseUrl).toEqual("https://scicat.eu/api");
+    expect(LoopBackConfig.getPath()).toEqual("https://scicat.eu/api");
   }));
 
   it(`should navigate to home when clicking the title'`, () => {
@@ -57,5 +57,27 @@ describe("AppComponent", () => {
 
     titleEl.nativeElement.click();
     expect(navigateSpy).toHaveBeenCalledWith(["/"]);
+  });
+
+  it("should render footer message links from config", () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    const footerLinks = fixture.debugElement.query(By.css(".footer-links"));
+    const anchors = footerLinks.queryAll(By.css("a"));
+
+    expect(footerLinks.nativeElement.textContent).toContain(
+      "For more information visit SciCat:",
+    );
+    expect(footerLinks.query(By.css("strong")).nativeElement.textContent).toBe(
+      "SciCat",
+    );
+    expect(anchors.length).toBe(2);
+    expect(anchors[0].nativeElement.textContent).toBe("Data policy");
+    expect(anchors[0].nativeElement.href).toBe("https://scicat.eu/data-policy");
+    expect(anchors[1].nativeElement.textContent).toBe("Documentation");
+    expect(anchors[1].nativeElement.href).toBe(
+      "https://scicat.eu/documentation",
+    );
   });
 });

--- a/src/app/publisheddata-details/publisheddata-details.component.spec.ts
+++ b/src/app/publisheddata-details/publisheddata-details.component.spec.ts
@@ -24,7 +24,7 @@ describe("PublisheddataDetailsComponent", () => {
   let component: PublisheddataDetailsComponent;
   let fixture: ComponentFixture<PublisheddataDetailsComponent>;
 
-  const scicatBaseUrl = "https://scicat.esss.se";
+  const scicatBaseUrl = "https://scicat.eu/scicat";
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -87,8 +87,7 @@ describe("PublisheddataDetailsComponent", () => {
     });
 
     it("should return true if dataDescription is URL", () => {
-      const dataDescription =
-        "https://github.com/ess-dmsc/ess_file_formats/wiki/NeXus";
+      const dataDescription = "https://scicat.eu/dataset-description";
 
       const isUrl = component.isUrl(dataDescription);
 

--- a/src/app/shared/MockStubs.ts
+++ b/src/app/shared/MockStubs.ts
@@ -107,20 +107,32 @@ export class MockAppConfigService extends AppConfigService {
     production: false,
     accessDataHref: "someurl",
     directMongoAccess: true,
-    facility: "ess",
+    facility: "the_facility",
     accessInstructions:
       "Instructions: Login with brightness username and password",
-    scicatBaseUrl: "https://scicat.esss.se",
-    lbBaseUrl: "https://scicat.esss.se/api",
+    scicatBaseUrl: "https://scicat.eu/scicat",
+    lbBaseUrl: "https://scicat.eu/api",
     retrieveToEmail: {
       option: "URLs",
       username: "lp_service",
       title: "An email",
       confirmMessage: "aMessage",
     },
-    showLogoBanner: true,
     oaiProviderRoute: null,
     logoBanner: "",
+    footerMessage: {
+      text: "For more information visit <strong>SciCat</strong>:",
+      links: [
+        {
+          label: "Data policy",
+          url: "https://scicat.eu/data-policy",
+        },
+        {
+          label: "Documentation",
+          url: "https://scicat.eu/documentation",
+        },
+      ],
+    },
   };
 
   async loadAppConfig(): Promise<void> {}

--- a/src/assets/config.example.json
+++ b/src/assets/config.example.json
@@ -8,8 +8,20 @@
   "oaiProviderRoute": "http://localhost:3001",
   "production": false,
   "scicatBaseUrl": "http://localhost",
-  "showLogoBanner": true,
   "statusCode": "INFO",
   "statusMessage": "This is a customizable status message",
-  "contactEmail": "support@scicat.eu"
+  "contactEmail": "support@scicat.eu",
+  "footerMessage": {
+    "text": "For more information visit <strong>SciCat</strong>:",
+    "links": [
+      {
+        "label": "Data policy",
+        "url": "https://scicat.eu/data-policy"
+      },
+      {
+        "label": "Documentation",
+        "url": "https://scicat.eu/documentation"
+      }
+    ]
+  }
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -15,5 +15,4 @@ export const environment = {
   oaiProviderRoute: "https://doi2.psi.ch/oaipmh/Publication",
   production: true,
   scicatBaseUrl: null,
-  showLogoBanner: false,
 };

--- a/src/environments/environment.dmsc.ts
+++ b/src/environments/environment.dmsc.ts
@@ -13,5 +13,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",
-  showLogoBanner: true,
 };

--- a/src/environments/environment.dmscdev.ts
+++ b/src/environments/environment.dmscdev.ts
@@ -13,5 +13,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",
-  showLogoBanner: true,
 };

--- a/src/environments/environment.dmscprod.ts
+++ b/src/environments/environment.dmscprod.ts
@@ -13,5 +13,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat.esss.se",
-  showLogoBanner: true,
 };

--- a/src/environments/environment.docker.ts
+++ b/src/environments/environment.docker.ts
@@ -14,5 +14,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: false,
   scicatBaseUrl: "https://scicat.esss.se",
-  showLogoBanner: true,
 };

--- a/src/environments/environment.essdev.ts
+++ b/src/environments/environment.essdev.ts
@@ -13,5 +13,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: false,
   scicatBaseUrl: "https://scitest.esss.lu.se",
-  showLogoBanner: false,
 };

--- a/src/environments/environment.essprod.ts
+++ b/src/environments/environment.essprod.ts
@@ -13,5 +13,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat.ess.eu",
-  showLogoBanner: true,
 };

--- a/src/environments/environment.maxivdemo.ts
+++ b/src/environments/environment.maxivdemo.ts
@@ -13,5 +13,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat-demo.maxiv.lu.se",
-  showLogoBanner: false,
 };

--- a/src/environments/environment.maxivdev.ts
+++ b/src/environments/environment.maxivdev.ts
@@ -13,5 +13,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat-test.maxiv.lu.se",
-  showLogoBanner: false,
 };

--- a/src/environments/environment.maxivprod.ts
+++ b/src/environments/environment.maxivprod.ts
@@ -13,5 +13,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: "https://scicat.maxiv.lu.se",
-  showLogoBanner: false,
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -10,5 +10,4 @@ export const environment = {
   oaiProviderRoute: "https://doi.psi.ch/oaipmh/Publication",
   production: true,
   scicatBaseUrl: null,
-  showLogoBanner: false,
 };

--- a/src/environments/environment.qa.ts
+++ b/src/environments/environment.qa.ts
@@ -8,5 +8,4 @@ export const environment = {
   oaiProviderRoute: null,
   production: true,
   scicatBaseUrl: null,
-  showLogoBanner: false,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,12 +8,24 @@ export const environment = {
     "Instructions: Login with brightness username and password",
   directMongoAccess: true,
   doiBaseUrl: "https://doi.org/",
-  facility: "ess",
+  facility: "the_facility",
   lbBaseUrl: "http://localhost:3000",
   oaiProviderRoute: "http://127.0.0.1:3001",
   production: false,
-  scicatBaseUrl: "https://scicat.esss.se",
-  showLogoBanner: true,
+  scicatBaseUrl: "http://localhost",
+  footerMessage: {
+    text: "For more information visit <strong>SciCat</strong>:",
+    links: [
+      {
+        label: "Data policy",
+        url: "https://scicat.eu/data-policy",
+      },
+      {
+        label: "Documentation",
+        url: "https://scicat.eu/documentation",
+      },
+    ],
+  },
 };
 
 /*


### PR DESCRIPTION
## Description

Customizable footer message with free text and links.

Removed showLogoBanner (as per Max request)

## Motivation

We would like to have links to the data policy.

<img width="907" height="120" alt="image" src="https://github.com/user-attachments/assets/355feed3-005a-4829-b46d-af73be980f3b" />
